### PR TITLE
fix: compdef: unknown command or service: crystal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,13 @@
 
 * `crb` aliases `crystal build`
 
-* `crc` aliases `crystal compile` (deprecated, use build instead)
-
 * `crd` aliases `crystal deps`
 
 * `crdo` aliases `crystal docs`
 
 * `cren` aliases `crystal env`
 
-* `cre` aliases `crystal eval`
+* `crev` aliases `crystal eval`
 
 * `crp` aliases `crystal play`
 

--- a/crystal.plugin.zsh
+++ b/crystal.plugin.zsh
@@ -9,7 +9,6 @@ function _crystal_command () {
 alias crystal='_crystal_command'
 
 alias cr='crystal'
-compdef cr='crystal'
 
 alias cri='crystal init'
 compdef _crystal cri='crystal init'


### PR DESCRIPTION
Hi @veelenga, I receive the error above on Oh my Zsh! installation on Ubuntu 20.04, but I think is changed something (last commit from 3 years ago).

In this way I fixed and I remove the deprecated crystal compile too.